### PR TITLE
Bugfix/eja eli 327 fix flipflopping permissions

### DIFF
--- a/infrastructure/modules/kinesis_firehose/kms.tf
+++ b/infrastructure/modules/kinesis_firehose/kms.tf
@@ -45,7 +45,6 @@ data "aws_iam_policy_document" "firehose_kms_key_policy" {
     resources = ["*"]
   }
 
-  # Your existing statements below...
   statement {
     sid    = "AllowFirehoseAccess"
     effect = "Allow"
@@ -110,5 +109,3 @@ data "aws_iam_policy_document" "firehose_kms_key_policy" {
     resources = [aws_kms_key.firehose_cmk.arn]
   }
 }
-
-

--- a/infrastructure/modules/s3/kms.tf
+++ b/infrastructure/modules/s3/kms.tf
@@ -14,21 +14,3 @@ resource "aws_kms_alias" "storage_bucket_cmk" {
   name          = "alias/${terraform.workspace == "default" ? "" : "${terraform.workspace}-"}${var.bucket_name}-cmk"
   target_key_id = aws_kms_key.storage_bucket_cmk.key_id
 }
-
-resource "aws_kms_key_policy" "storage_bucket_cmk" {
-  key_id = aws_kms_key.storage_bucket_cmk.id
-  policy = data.aws_iam_policy_document.storage_bucket_cmk.json
-}
-
-data "aws_iam_policy_document" "storage_bucket_cmk" {
-  statement {
-    sid    = "Enable IAM User Permissions for s3 buckets"
-    effect = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    }
-    actions   = ["kms:*"]
-    resources = [aws_kms_key.storage_bucket_cmk.arn]
-  }
-}

--- a/infrastructure/modules/s3/kms.tf
+++ b/infrastructure/modules/s3/kms.tf
@@ -1,4 +1,5 @@
 resource "aws_kms_key" "storage_bucket_cmk" {
+  #checkov:skip=CKV2_AWS_64: KMS key policy is defined in api-layer iam_policies.tf
   description             = "${terraform.workspace == "default" ? "" : "${terraform.workspace}-"}${var.bucket_name} Master Key"
   deletion_window_in_days = 14
   is_enabled              = true

--- a/infrastructure/modules/s3/outputs.tf
+++ b/infrastructure/modules/s3/outputs.tf
@@ -21,3 +21,7 @@ output "storage_bucket_id" {
 output "storage_bucket_kms_key_arn" {
   value = aws_kms_key.storage_bucket_cmk.arn
 }
+
+output "storage_bucket_kms_key_id" {
+  value = aws_kms_key.storage_bucket_cmk.id
+}

--- a/infrastructure/modules/s3/s3.tf
+++ b/infrastructure/modules/s3/s3.tf
@@ -14,39 +14,6 @@ resource "aws_s3_bucket_versioning" "storage_bucket_versioning_config" {
   }
 }
 
-# ensure only secure transport is allowed
-
-resource "aws_s3_bucket_policy" "storage_bucket" {
-  bucket = aws_s3_bucket.storage_bucket.id
-  policy = data.aws_iam_policy_document.storage_s3_bucket_policy.json
-}
-
-data "aws_iam_policy_document" "storage_s3_bucket_policy" {
-  statement {
-    sid = "AllowSslRequestsOnly"
-    actions = [
-      "s3:*",
-    ]
-    effect = "Deny"
-    resources = [
-      aws_s3_bucket.storage_bucket.arn,
-      "${aws_s3_bucket.storage_bucket.arn}/*",
-    ]
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    condition {
-      test = "Bool"
-      values = [
-        "false",
-      ]
-
-      variable = "aws:SecureTransport"
-    }
-  }
-}
-
 # Block public access to the bucket
 resource "aws_s3_bucket_public_access_block" "storage_bucket_block_public_access" {
   bucket = aws_s3_bucket.storage_bucket.id

--- a/infrastructure/stacks/api-layer/iam_policies.tf
+++ b/infrastructure/stacks/api-layer/iam_policies.tf
@@ -235,7 +235,6 @@ data "aws_iam_policy_document" "s3_audit_kms_key_policy" {
     actions   = ["kms:*"]
     resources = ["*"]
   }
-
   statement {
     sid    = "AllowLambdaFullWrite"
     effect = "Allow"
@@ -277,9 +276,3 @@ resource "aws_iam_role_policy" "lambda_firehose_policy" {
   role   = aws_iam_role.eligibility_lambda_role.id
   policy = data.aws_iam_policy_document.lambda_firehose_write_policy.json
 }
-
-
-
-
-
-

--- a/infrastructure/stacks/api-layer/iam_policies.tf
+++ b/infrastructure/stacks/api-layer/iam_policies.tf
@@ -71,6 +71,70 @@ data "aws_iam_policy_document" "s3_rules_bucket_policy" {
   }
 }
 
+# ensure only secure transport is allowed
+
+resource "aws_s3_bucket_policy" "rules_s3_bucket" {
+  bucket = module.s3_rules_bucket.storage_bucket_id
+  policy = data.aws_iam_policy_document.rules_s3_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "rules_s3_bucket_policy" {
+  statement {
+    sid = "AllowSslRequestsOnly"
+    actions = [
+      "s3:*",
+    ]
+    effect = "Deny"
+    resources = [
+      module.s3_rules_bucket.storage_bucket_arn,
+      "${module.s3_rules_bucket.storage_bucket_arn}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test = "Bool"
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "audit_s3_bucket" {
+  bucket = module.s3_audit_bucket.storage_bucket_id
+  policy = data.aws_iam_policy_document.audit_s3_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "audit_s3_bucket_policy" {
+  statement {
+    sid = "AllowSslRequestsOnly"
+    actions = [
+      "s3:*",
+    ]
+    effect = "Deny"
+    resources = [
+      module.s3_audit_bucket.storage_bucket_arn,
+      "${module.s3_audit_bucket.storage_bucket_arn}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test = "Bool"
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+  }
+}
+
 # Attach s3 read policy to Lambda role
 resource "aws_iam_role_policy" "lambda_s3_read_policy" {
   name   = "S3ReadAccess"
@@ -216,7 +280,7 @@ data "aws_iam_policy_document" "s3_rules_kms_key_policy" {
 }
 
 resource "aws_kms_key_policy" "s3_rules_kms_key" {
-  key_id = module.s3_rules_bucket.storage_bucket_kms_key_arn
+  key_id = module.s3_rules_bucket.storage_bucket_kms_key_id
   policy = data.aws_iam_policy_document.s3_rules_kms_key_policy.json
 }
 
@@ -253,7 +317,7 @@ data "aws_iam_policy_document" "s3_audit_kms_key_policy" {
 }
 
 resource "aws_kms_key_policy" "s3_audit_kms_key" {
-  key_id = module.s3_audit_bucket.storage_bucket_kms_key_arn
+  key_id = module.s3_audit_bucket.storage_bucket_kms_key_id
   policy = data.aws_iam_policy_document.s3_audit_kms_key_policy.json
 }
 

--- a/infrastructure/stacks/api-layer/truststore_s3_bucket.tf
+++ b/infrastructure/stacks/api-layer/truststore_s3_bucket.tf
@@ -13,6 +13,25 @@ resource "aws_s3_bucket_policy" "truststore" {
 }
 
 data "aws_iam_policy_document" "truststore_api_gateway" {
+    # Deny non-SSL
+    statement {
+      sid = "AllowSslRequestsOnly"
+      actions = ["s3:*"]
+      effect  = "Deny"
+      resources = [
+        module.s3_truststore_bucket.storage_bucket_arn,
+        "${module.s3_truststore_bucket.storage_bucket_arn}/*"
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
   statement {
     sid    = "Enable S3 access permissions for API Gateway"
     effect = "Allow"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixing some issues with Terraform deployment whereby permissions on objects were 'flipping' between two different policies defined in the code.

## Context

We need consistent deployments, especially in terms of ensuring security best practices are in place
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
