### PR TITLE
eli-386 blocking s3 public access at account level

### DIFF
--- a/infrastructure/stacks/api-layer/s3_buckets.tf
+++ b/infrastructure/stacks/api-layer/s3_buckets.tf
@@ -16,3 +16,8 @@ module "s3_audit_bucket" {
   stack_name             = local.stack_name
   workspace              = terraform.workspace
 }
+
+resource "aws_s3_account_public_access_block" "block_public_access" {
+  block_public_acls   = true
+  block_public_policy = true
+}

--- a/infrastructure/stacks/iams-developer-roles/github_actions_policies.tf
+++ b/infrastructure/stacks/iams-developer-roles/github_actions_policies.tf
@@ -164,6 +164,14 @@ resource "aws_iam_policy" "s3_management" {
           "arn:aws:s3:::*eligibility-signposting-api-${var.environment}-truststore-access-logs",
           "arn:aws:s3:::*eligibility-signposting-api-${var.environment}-truststore-access-logs/*",
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetAccountPublicAccessBlock",
+          "s3:PutAccountPublicAccessBlock"
+        ],
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding account level s3 public block
## Context

We block public access to s3 buckets we create. Adding in account level protections also means malicious actors / inadvertent s3 creation is protected by default from being made public.
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
