### PR TITLE
eli-304 changing eventbridge format to single line

### DIFF
--- a/infrastructure/stacks/api-layer/eventbridge.tf
+++ b/infrastructure/stacks/api-layer/eventbridge.tf
@@ -73,21 +73,7 @@ resource "aws_cloudwatch_event_target" "firehose_target" {
       reason     = "$.detail.state.reason"
     }
 
-    # Use a heredoc string so EventBridge placeholders like <time> are not JSON-escaped
-    # (jsonencode would turn < and > into \u003c/\u003e, preventing substitution).
-    input_template = <<TEMPLATE
-{
-  "time": "<time>",
-  "source": "elid-${var.environment}:cloudwatch:alarm",
-  "sourcetype": "aws:cloudwatch:alarm",
-  "event": {
-    "alarm_name": "<alarm_name>",
-    "new_state": "<new_state>",
-    "old_state": "<old_state>",
-    "reason": "<reason>",
-    "region": "<region>"
-  }
-}
-TEMPLATE
+    # Eventbridge + Firehose splits events if we don't put on single line
+    input_template = "\"{ \\\"time\\\": \\\"<time>\\\", \\\"source\\\": \\\"elid-${var.environment}:cloudwatch:alarm\\\", \\\"sourcetype\\\": \\\"aws:cloudwatch:alarm\\\", \\\"event\\\": { \\\"alarm_name\\\": \\\"<alarm_name>\\\", \\\"new_state\\\": \\\"<new_state>\\\", \\\"old_state\\\": \\\"<old_state>\\\", \\\"reason\\\": \\\"<reason>\\\", \\\"region\\\": \\\"<region>\\\" } }\""
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Amending eventbridge format to be single line, to avoid it being split in Splunk
## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
