### PR TITLE
eli-470 updating prod subdomain to include national.nhs.uk

### DIFF
--- a/infrastructure/stacks/api-layer/locals.tf
+++ b/infrastructure/stacks/api-layer/locals.tf
@@ -2,7 +2,7 @@ locals {
   stack_name = "api-layer"
 
   api_subdomain   = var.environment
-  api_domain_name = "eligibility-signposting-api.nhs.uk"
+  api_domain_name = var.environment == "prod" ? "eligibility-signposting-api.national.nhs.uk" : "eligibility-signposting-api.nhs.uk"
 
   # PEM file for certificate
   pem_file_content = join("\n", [


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
**Based off v1.0.0-rc.2**

Our Prod subdomain has to be prod.eligibility-signposting-api.**national**.nhs.uk and not just prod.eligibility-signposting-api.nhs.uk
## Context

We need to make sure our API Gateway is set up for the different domain naming pattern.
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
