### PR TITLE
bugfix - adding dynamoDB UpdateTable permissions to the Github OID role, to unblock dev deployments

### DIFF
--- a/infrastructure/stacks/iams-developer-roles/github_actions_policies.tf
+++ b/infrastructure/stacks/iams-developer-roles/github_actions_policies.tf
@@ -105,6 +105,7 @@ resource "aws_iam_policy" "dynamodb_management" {
             "dynamodb:CreateTable",
             "dynamodb:TagResource",
             "dynamodb:ListTagsOfResource",
+            "dynamodb:UpdateTable",
           ],
           Resource = [
             "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/*eligibility-signposting-api-${var.environment}-eligibility_datastore"

--- a/infrastructure/stacks/iams-developer-roles/iams_permissions_boundary.tf
+++ b/infrastructure/stacks/iams-developer-roles/iams_permissions_boundary.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "permissions_boundary" {
       "dynamodb:CreateTable",
       "dynamodb:TagResource",
       "dynamodb:ListTagsOfResource",
+      "dynamodb:UpdateTable",
 
       # EC2 - networking infrastructure
       "ec2:Describe*",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding permissions for dynamoDB:UpdateTable to Github OIDC role
## Context

We recently added changes to dynamoDB encryption, which failed on deployment as the Github role did not have permissions to update existing tables. Adding these permissions
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
