### PR TITLE
Eli 785/audit trail status override

### DIFF
--- a/src/eligibility_signposting_api/audit/audit_context.py
+++ b/src/eligibility_signposting_api/audit/audit_context.py
@@ -107,6 +107,7 @@ class AuditContext:
             suitability_rules=audit_suitability_rule,
             action_rule=audit_action_rule,
             actions=audit_actions,
+            status_text_override=action_detail.status_text_override,
         )
 
         g.audit_log.response.condition.append(audit_condition)

--- a/src/eligibility_signposting_api/audit/audit_models.py
+++ b/src/eligibility_signposting_api/audit/audit_models.py
@@ -83,6 +83,7 @@ class AuditCondition(CamelCaseBaseModel):
     suitability_rules: list[AuditSuitabilityRule] | None = None
     action_rule: AuditRedirectRule | None = None
     actions: list[AuditAction] | None = Field(default_factory=list)
+    status_text_override: str | None = None
 
 
 class ResponseAuditData(CamelCaseBaseModel):

--- a/tests/integration/lambda/test_app_running_as_lambda.py
+++ b/tests/integration/lambda/test_app_running_as_lambda.py
@@ -247,6 +247,7 @@ def test_given_nhs_number_in_path_matches_with_nhs_number_in_headers_and_check_i
             ],
             "actionRule": None,
             "actions": [],
+            "statusTextOverride": None,
         }
     ]
 
@@ -495,6 +496,7 @@ def test_given_person_has_unique_status_for_different_conditions_with_audit(  # 
             "suitabilityRules": None,
             "actionRule": None,
             "actions": [],
+            "statusTextOverride": None,
         },
         {
             "campaignId": covid_campaign.id,
@@ -527,6 +529,7 @@ def test_given_person_has_unique_status_for_different_conditions_with_audit(  # 
             ],
             "actionRule": None,
             "actions": [],
+            "statusTextOverride": None,
         },
         {
             "campaignId": flu_campaign.id,
@@ -557,6 +560,7 @@ def test_given_person_has_unique_status_for_different_conditions_with_audit(  # 
                     "actionUrlLabel": None,
                 }
             ],
+            "statusTextOverride": None,
         },
     ]
 

--- a/tests/unit/audit/test_audit_context.py
+++ b/tests/unit/audit/test_audit_context.py
@@ -196,6 +196,185 @@ def test_append_audit_condition_adds_condition_to_audit_log_on_g_for_actionable_
         assert cond.eligibility_cohort_groups[0].cohort_text == "CohortDescription1"
 
 
+def test_append_audit_condition_with_status_override_text(app):
+    suggested_actions: list[SuggestedAction] | None
+    condition_name: ConditionName
+    campaign_details: tuple[CampaignID | None, CampaignVersion | None]
+
+    # Build dummy variables sufficient to be able to call append_audit_condition.
+    suggested_actions = [
+        SuggestedAction(
+            internal_action_code=InternalActionCode("InternalActionCode1"),
+            action_code=ActionCode("ActionCode1"),
+            action_type=ActionType("ActionType1"),
+            action_description=ActionDescription("ActionDescription1"),
+            url_link=UrlLink(HttpUrl("https://example.com/")),
+            url_label=UrlLabel("ActionLabel1"),
+        )
+    ]
+    condition_name = ConditionName("Condition1")
+    iteration = IterationFactory.build(version=12345)
+    audit_rules = [
+        Reason(
+            rule_type=RuleType.redirect,
+            rule_name=RuleName("RedirectRuleName1"),
+            rule_code=RuleCode("RedirectRuleCode1"),
+            rule_text=RuleText("RedirectRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+        Reason(
+            rule_type=RuleType.filter,
+            rule_name=RuleName("FilterRuleName1"),
+            rule_code=RuleCode("FilterRuleCode1"),
+            rule_text=RuleText("FilterRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+        Reason(
+            rule_type=RuleType.suppression,
+            rule_name=RuleName("SuppressionRuleName1"),
+            rule_code=RuleCode("SuppressionRuleCode1"),
+            rule_text=RuleText("SuppressionRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+    ]
+    cohort_group_result = CohortGroupResult(
+        status=Status.actionable,
+        cohort_code="CohortCode1",
+        description="CohortDescription1",
+        audit_rules=audit_rules,
+        reasons=audit_rules,
+    )
+    iteration_result = IterationResult(
+        status=Status.actionable,
+        status_text=StatusText(
+            "Override text you should see"
+        ),  # value overwritten by get_eligibility_status prior to append_audit_condition being called.
+        cohort_results=[cohort_group_result],
+        actions=suggested_actions,
+    )
+    status_text_override = StatusText(
+        "Override text you should see (in override field)"
+    )  # Value in real run will exactly match status_text, differentiated here for testing.
+    campaign_details = (CampaignID("CampaignID1"), CampaignVersion(123))
+    matched_action_detail = MatchedActionDetail(
+        campaign_config.RuleName("RedirectRuleName1"),
+        campaign_config.RulePriority(1),
+        suggested_actions,
+        status_text_override,
+    )
+    iteration_result_summary = IterationResultSummary(
+        iteration_result,
+        iteration,
+        campaign_details[0],
+        campaign_details[1],
+        {CohortLabel("CohortCode1"): cohort_group_result},
+    )
+
+    # Initialise test data.
+    with app.app_context():
+        g.audit_log = AuditEvent()
+
+        AuditContext.append_audit_condition(condition_name, iteration_result_summary, matched_action_detail)
+
+        # Get audit_condition outputs.
+        cond = g.audit_log.response.condition[0]
+
+        # Assert that override status text actually comes out.
+        assert cond.status_text == "Override text you should see"
+        assert cond.status_text_override == "Override text you should see (in override field)"
+
+
+def test_append_audit_condition_without_override_status_text(app):
+    # Trivial but explicit test of append_audit_condition being called where status_test_override is not provided.
+    suggested_actions: list[SuggestedAction] | None
+    condition_name: ConditionName
+    campaign_details: tuple[CampaignID | None, CampaignVersion | None]
+
+    # Build dummy variables sufficient to be able to call append_audit_condition.
+    suggested_actions = [
+        SuggestedAction(
+            internal_action_code=InternalActionCode("InternalActionCode1"),
+            action_code=ActionCode("ActionCode1"),
+            action_type=ActionType("ActionType1"),
+            action_description=ActionDescription("ActionDescription1"),
+            url_link=UrlLink(HttpUrl("https://example.com/")),
+            url_label=UrlLabel("ActionLabel1"),
+        )
+    ]
+    condition_name = ConditionName("Condition1")
+    iteration = IterationFactory.build(version=12345)
+    audit_rules = [
+        Reason(
+            rule_type=RuleType.redirect,
+            rule_name=RuleName("RedirectRuleName1"),
+            rule_code=RuleCode("RedirectRuleCode1"),
+            rule_text=RuleText("RedirectRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+        Reason(
+            rule_type=RuleType.filter,
+            rule_name=RuleName("FilterRuleName1"),
+            rule_code=RuleCode("FilterRuleCode1"),
+            rule_text=RuleText("FilterRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+        Reason(
+            rule_type=RuleType.suppression,
+            rule_name=RuleName("SuppressionRuleName1"),
+            rule_code=RuleCode("SuppressionRuleCode1"),
+            rule_text=RuleText("SuppressionRuleDescription1"),
+            matcher_matched=True,
+            rule_priority=RulePriority("1"),
+        ),
+    ]
+    cohort_group_result = CohortGroupResult(
+        status=Status.actionable,
+        cohort_code="CohortCode1",
+        description="CohortDescription1",
+        audit_rules=audit_rules,
+        reasons=audit_rules,
+    )
+    iteration_result = IterationResult(
+        status=Status.actionable,
+        status_text=StatusText("Default status text"),
+        cohort_results=[cohort_group_result],
+        actions=suggested_actions,
+    )
+    status_text_override = None  # Will default to None when not provided, made explicit here for testing.
+    campaign_details = (CampaignID("CampaignID1"), CampaignVersion(123))
+    matched_action_detail = MatchedActionDetail(
+        campaign_config.RuleName("RedirectRuleName1"),
+        campaign_config.RulePriority(1),
+        suggested_actions,
+        status_text_override,
+    )
+    iteration_result_summary = IterationResultSummary(
+        iteration_result,
+        iteration,
+        campaign_details[0],
+        campaign_details[1],
+        {CohortLabel("CohortCode1"): cohort_group_result},
+    )
+
+    # Initialise test data.
+    with app.app_context():
+        g.audit_log = AuditEvent()
+
+        AuditContext.append_audit_condition(condition_name, iteration_result_summary, matched_action_detail)
+
+        # Get audit_condition outputs.
+        cond = g.audit_log.response.condition[0]
+
+        # Assert that override status text actually comes out.
+        assert cond.status_text == "Default status text"
+        assert cond.status_text_override is None
+
+
 def test_should_append_audit_suppression_rules_for_actionable_status(app):
     condition_name: ConditionName
     campaign_details: tuple[CampaignID | None, CampaignVersion | None]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding new field status_text_override to audit classes and related tests.

## Context

As part of ELI-727 adding configurable status text to API response.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
